### PR TITLE
Move AQL cheatsheets to their own page and a few more fixes

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -2,7 +2,7 @@
 
 The [Action Language for EMF (ALE)](https://github.com/gemoc/ale-lang) is a language used to make Ecore metamodels executable. Define the behavior of your models in a dedicated, interpreted and object-oriented language and **run it in minutes!**
 
-![ALE allows to weave behavior into Ecore models](images/overview.png)
+![ALE allows to weave behavior into Ecore models](https://raw.githubusercontent.com/gemoc/ale-lang/master/docs/img/demo.gif)
 
 {{% notice tip %}}
 With ALE, you can execute your models right from your IDE: you no longer need to spend time generating and tweaking Java code!

--- a/content/reference/_index.md
+++ b/content/reference/_index.md
@@ -1,5 +1,5 @@
 +++
-title = "Reference"
+title = "Language Reference"
 weight = 4
 chapter = true
 pre = "<b>4. </b>"

--- a/content/reference/aql_cheatsheet.md
+++ b/content/reference/aql_cheatsheet.md
@@ -1,0 +1,59 @@
++++
+title = "AQL cheatsheets"
+weight = 3
++++
+
+See [AQL syntax reference](https://www.eclipse.org/acceleo/documentation/aql.html#SyntaxReference) for an in-depth presentation of the language.
+
+-------------------
+
+### Type of
+
+```java
+anEPackage.oclIsKindOf(ecore::ENamedElement) // true
+anEPackage.oclIsTypeOf(ecore::ENamedElement) // false
+```
+
+### Services for collections
+
+```
+OrderedSet{'a', 'b', 'c'} + OrderedSet{'c', 'b', 'f'}
+Sequence{'a', 'b', 'c'}->any(str | str.size() = 1)
+Sequence{'a', 'b', 'c'}->asOrderedSet()
+OrderedSet{'a', 'b', 'c'}->asSequence()
+Sequence{'a', 'b', 'c', 'c', 'a'}->asSet()
+Sequence{'a', 'b', 'c'}->at(1)
+Sequence{'a', 'b', 'c'}->collect(str | str.toUpper())
+OrderedSet{'a', 'b', 'c'}->concat(Sequence{'d', 'e'})
+OrderedSet{'a', 'b', 'c'}->count('d')
+Sequence{'a', 'b', 'c'}->excludes('a')
+Sequence{'a', 'b'}->excludesAll(OrderedSet{'a','f'})
+OrderedSet{'a', 'b', 'c'}->excluding('c')
+Sequence{'a', 'b', 'c'}->exists(str | str.size() > 5)
+Sequence{anEClass, anEAttribute}->filter(ecore::EStructuralFeature)
+Sequence{'a', 'b', 'c'}->first()
+Sequence{'a', 'b', 'c'}->forAll(str | str.size() = 1)
+Sequence{'a', 'b', 'c'}->includes('d')
+Sequence{'a', 'b', 'c'}->includesAll(OrderedSet{'a', 'f'})
+OrderedSet{1, 2, 3, 4}->indexOf(3)
+OrderedSet{'a', 'b', 'c'}->insertAt(2, 'f')
+OrderedSet{'a', 'b', 'c'}->intersection(OrderedSet{'a', 'f'})
+OrderedSet{'a', 'b', 'c'}->isEmpty()
+Sequence{'a', 'b', 'c'}->isUnique(str | str.size())
+Sequence{'a', 'b', 'c'}->last()
+OrderedSet{'a', 'b', 'c'}->notEmpty()
+Sequence{'a', 'b', 'c'}->one(str | str.equals('a'))
+OrderedSet{'a', 'b', 'c'}->prepend('f')
+OrderedSet{'a', 'b', 'c'}->reject(str | str.equals('a'))
+OrderedSet{'a', 'b', 'c'}->reverse()
+Sequence{'a', 'b', 'c'}->select(str | str.equals('a'))
+Sequence{'a', 'b', 'c'}->sep('[', '-', ']')
+Sequence{'a', 'b', 'c'}->sep('-')
+Sequence{'a', 'b', 'c'}->size()
+Sequence{'aa', 'bbb', 'c'}->sortedBy(str | str.size())
+Sequence{'a', 'b', 'c'} - Sequence{'c', 'b', 'f'}
+OrderedSet{'a', 'b', 'c'}->subOrderedSet(1, 2)
+Sequence{'a', 'b', 'c'}->subSequence(1, 2)
+Sequence{1, 2, 3, 4}->sum()
+Sequence{'a', 'b', 'c'}->union(Sequence{'d', 'c'})
+```

--- a/content/reference/syntax.md
+++ b/content/reference/syntax.md
@@ -599,7 +599,7 @@ open class Circle {
     }
 }
 ```
-{% /unsafeExpand %}
+{{% /unsafeExpand %}}
 
 {{% notice tip %}}
 See also [defining operations](#defining-operations) for further details about operation syntax.
@@ -660,66 +660,6 @@ open class CompositeState extends simplefsm.State {
 }
 ```
 {{% /unsafeExpand %}}
-
----------------------------------------------------------------------
-
-AQL
----
-
-Some cheatsheets on AQL expressions
-
-See [AQL syntax reference](https://www.eclipse.org/acceleo/documentation/aql.html#SyntaxReference) for more details.
-
-### Type of
-
-```
-anEPackage.oclIsKindOf(ecore::ENamedElement) //true
-anEPackage.oclIsTypeOf(ecore::ENamedElement) //false
-```
-
-### Services for collections
-
-```
-OrderedSet{'a', 'b', 'c'} + OrderedSet{'c', 'b', 'f'}
-Sequence{'a', 'b', 'c'}->any(str | str.size() = 1)
-Sequence{'a', 'b', 'c'}->asOrderedSet()
-OrderedSet{'a', 'b', 'c'}->asSequence()
-Sequence{'a', 'b', 'c', 'c', 'a'}->asSet()
-Sequence{'a', 'b', 'c'}->at(1)
-Sequence{'a', 'b', 'c'}->collect(str | str.toUpper())
-OrderedSet{'a', 'b', 'c'}->concat(Sequence{'d', 'e'})
-OrderedSet{'a', 'b', 'c'}->count('d')
-Sequence{'a', 'b', 'c'}->excludes('a')
-Sequence{'a', 'b'}->excludesAll(OrderedSet{'a','f'})
-OrderedSet{'a', 'b', 'c'}->excluding('c')
-Sequence{'a', 'b', 'c'}->exists(str | str.size() > 5)
-Sequence{anEClass, anEAttribute}->filter(ecore::EStructuralFeature)
-Sequence{'a', 'b', 'c'}->first()
-Sequence{'a', 'b', 'c'}->forAll(str | str.size() = 1)
-Sequence{'a', 'b', 'c'}->includes('d')
-Sequence{'a', 'b', 'c'}->includesAll(OrderedSet{'a', 'f'})
-OrderedSet{1, 2, 3, 4}->indexOf(3)
-OrderedSet{'a', 'b', 'c'}->insertAt(2, 'f')
-OrderedSet{'a', 'b', 'c'}->intersection(OrderedSet{'a', 'f'})
-OrderedSet{'a', 'b', 'c'}->isEmpty()
-Sequence{'a', 'b', 'c'}->isUnique(str | str.size())
-Sequence{'a', 'b', 'c'}->last()
-OrderedSet{'a', 'b', 'c'}->notEmpty()
-Sequence{'a', 'b', 'c'}->one(str | str.equals('a'))
-OrderedSet{'a', 'b', 'c'}->prepend('f')
-OrderedSet{'a', 'b', 'c'}->reject(str | str.equals('a'))
-OrderedSet{'a', 'b', 'c'}->reverse()
-Sequence{'a', 'b', 'c'}->select(str | str.equals('a'))
-Sequence{'a', 'b', 'c'}->sep('[', '-', ']')
-Sequence{'a', 'b', 'c'}->sep('-')
-Sequence{'a', 'b', 'c'}->size()
-Sequence{'aa', 'bbb', 'c'}->sortedBy(str | str.size())
-Sequence{'a', 'b', 'c'} - Sequence{'c', 'b', 'f'}
-OrderedSet{'a', 'b', 'c'}->subOrderedSet(1, 2)
-Sequence{'a', 'b', 'c'}->subSequence(1, 2)
-Sequence{1, 2, 3, 4}->sum()
-Sequence{'a', 'b', 'c'}->union(Sequence{'d', 'c'})
-```
 
 ---------------------------------------------------------------------
 

--- a/layouts/partials/logo.html
+++ b/layouts/partials/logo.html
@@ -1,2 +1,3 @@
 <a id="logo" href="https://echebbi.github.io/ale-lang-docs/"/>
-<img src="https://echebbi.github.io/ale-lang-docs/images/logo.png"/>
+    <img src="https://echebbi.github.io/ale-lang-docs/images/logo.png"/>
+</a>


### PR DESCRIPTION
### Changes

 - add GIF of demo to the homepage (for beauty and clarity)
 - move AQL cheatsheets to their own page (for clarity)
 - rename *Reference* chapter as *Language Reference* (for clarity)
 - fix a leaking link in logo that was preventing the use of the search bar